### PR TITLE
🔧 feat(workflow): ENABLE_PR_AUTO_COMMENT環境変数でON/OFFを追加

### DIFF
--- a/.github/workflows/pr-auto-comment.yml
+++ b/.github/workflows/pr-auto-comment.yml
@@ -8,6 +8,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  ENABLE_PR_AUTO_COMMENT: ${{ vars.ENABLE_PR_AUTO_COMMENT || 'true' }}
+
 jobs:
   auto-comment:
     runs-on: ubuntu-latest
@@ -17,10 +20,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PAT_ONIZUKA }}
           script: |
-            // 環境変数でON/OFFを制御（デフォルトはtrue）
-            const enabled = '${{ vars.ENABLE_PR_AUTO_COMMENT }}' !== 'false';
-
-            if (!enabled) {
+            if ('${{ env.ENABLE_PR_AUTO_COMMENT }}' !== 'true') {
               console.log('PR Auto Comment is disabled. Skipping...');
               return;
             }


### PR DESCRIPTION
## Summary 📝

PR自動コメントワークフローを環境変数からON/OFFできるようにしたよ！

## Changes 🔧

- `ENABLE_PR_AUTO_COMMENT` 環境変数を追加
- デフォルトは `true`（有効）
- `false` に設定すると自動コメントが無効になる

## 使い方 🎛️

GitHubの `Settings > Secrets and variables > Actions > Variables` から設定してね：

| 変数名 | 値 | 動作 |
|:------|:--|:------|
| `ENABLE_PR_AUTO_COMMENT` | 設定なし | ON（デフォルト） |
| `ENABLE_PR_AUTO_COMMENT` | `true` | ON |
| `ENABLE_PR_AUTO_COMMENT` | `false` | OFF |

## Test plan ✅

- [x] 環境変数の追加を確認
- [x] PR作成してワークフロー検証

## Purpose 🎯

自動コメントワークフローを簡単に有効/無効切り替えられるように！

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)